### PR TITLE
Chapter 11 code feedback

### DIFF
--- a/Chapter11/booktracker/application/Dockerfile
+++ b/Chapter11/booktracker/application/Dockerfile
@@ -2,9 +2,8 @@ FROM python:3.10
 
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-RUN apt-get update && apt-get install -y yarn
+RUN apt-get update && apt-get install -y yarn wait-for-it
 
-RUN mkdir /app
 WORKDIR /app
 
 COPY ./package.json /app/package.json
@@ -16,3 +15,4 @@ RUN pip install -r requirements.txt
 
 COPY ./booktracker /app/booktracker
 COPY ./ui /app/ui
+

--- a/Chapter11/booktracker/application/booktracker/blueprints/author/view.py
+++ b/Chapter11/booktracker/application/booktracker/blueprints/author/view.py
@@ -21,7 +21,9 @@ class AuthorListView(HTTPMethodView, attach=bp):
     async def get(request: Request, pagination: Pagination) -> HTTPResponse:
         executor = AuthorExecutor(request.app.ctx.postgres)
         kwargs = {**pagination.to_dict()}
-        getter: Callable[..., Awaitable[List[Author]]] = executor.get_all_authors
+        getter: Callable[
+            ..., Awaitable[List[Author]]
+        ] = executor.get_all_authors
 
         if name := request.args.get("name"):
             kwargs["name"] = name

--- a/Chapter11/booktracker/application/booktracker/blueprints/author/view.py
+++ b/Chapter11/booktracker/application/booktracker/blueprints/author/view.py
@@ -3,7 +3,7 @@ from typing import Awaitable, Callable, List
 
 from booktracker.common.csrf import csrf_protected
 from booktracker.common.pagination import Pagination
-from sanic import Blueprint, Request, json
+from sanic import Blueprint, HTTPResponse, Request, json
 from sanic.exceptions import NotFound
 from sanic.views import HTTPMethodView
 from sanic_ext import validate
@@ -17,7 +17,7 @@ logger = getLogger("booktracker")
 
 class AuthorListView(HTTPMethodView, attach=bp):
     @staticmethod
-    async def get(request: Request, pagination: Pagination):
+    async def get(request: Request, pagination: Pagination) -> HTTPResponse:
         executor = AuthorExecutor(request.app.ctx.postgres)
         kwargs = {**pagination.to_dict()}
         getter: Callable[
@@ -38,7 +38,7 @@ class AuthorListView(HTTPMethodView, attach=bp):
     @staticmethod
     @validate(json=CreateAuthorBody)
     @csrf_protected
-    async def post(request: Request, body: CreateAuthorBody):
+    async def post(request: Request, body: CreateAuthorBody) -> HTTPResponse:
         executor = AuthorExecutor(request.app.ctx.postgres)
         author = await executor.create_author(**body.to_dict())
         return json({"author": author}, status=201)

--- a/Chapter11/booktracker/application/booktracker/blueprints/author/view.py
+++ b/Chapter11/booktracker/application/booktracker/blueprints/author/view.py
@@ -1,12 +1,13 @@
 from logging import getLogger
 from typing import Awaitable, Callable, List
 
-from booktracker.common.csrf import csrf_protected
-from booktracker.common.pagination import Pagination
 from sanic import Blueprint, HTTPResponse, Request, json
 from sanic.exceptions import NotFound
 from sanic.views import HTTPMethodView
 from sanic_ext import validate
+
+from booktracker.common.csrf import csrf_protected
+from booktracker.common.pagination import Pagination
 
 from .executor import AuthorExecutor
 from .model import Author, CreateAuthorBody
@@ -20,9 +21,7 @@ class AuthorListView(HTTPMethodView, attach=bp):
     async def get(request: Request, pagination: Pagination) -> HTTPResponse:
         executor = AuthorExecutor(request.app.ctx.postgres)
         kwargs = {**pagination.to_dict()}
-        getter: Callable[
-            ..., Awaitable[List[Author]]
-        ] = executor.get_all_authors
+        getter: Callable[..., Awaitable[List[Author]]] = executor.get_all_authors
 
         if name := request.args.get("name"):
             kwargs["name"] = name

--- a/Chapter11/booktracker/application/booktracker/blueprints/book/executor.py
+++ b/Chapter11/booktracker/application/booktracker/blueprints/book/executor.py
@@ -14,7 +14,9 @@ class BookExecutor(BaseExecutor):
         offset: int = 0,
     ) -> List[Book]:
         query = self._queries["get_all_books"]
-        records = await self.db.fetch_all(query, {"limit": limit, "offset": offset})
+        records = await self.db.fetch_all(
+            query, {"limit": limit, "offset": offset}
+        )
         books = self.hydrator.hydrate(records, Book, True, exclude)
 
         return books

--- a/Chapter11/booktracker/application/booktracker/blueprints/book/executor.py
+++ b/Chapter11/booktracker/application/booktracker/blueprints/book/executor.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Any, List, Mapping, Optional
 
 from booktracker.blueprints.book.model import Book, Series
 from booktracker.common.dao.executor import BaseExecutor
@@ -76,7 +76,7 @@ class BookExecutor(BaseExecutor):
         values = {"title": title, "eid": eid}
         if record:
             values["book_id"] = record["book_id"]
-        book = self.hydrator.hydrate(values, Book, True)
+        book = self.hydrator.hydrate(values, Book, False)
 
         return book
 

--- a/Chapter11/booktracker/application/booktracker/blueprints/book/executor.py
+++ b/Chapter11/booktracker/application/booktracker/blueprints/book/executor.py
@@ -14,9 +14,7 @@ class BookExecutor(BaseExecutor):
         offset: int = 0,
     ) -> List[Book]:
         query = self._queries["get_all_books"]
-        records = await self.db.fetch_all(
-            query, {"limit": limit, "offset": offset}
-        )
+        records = await self.db.fetch_all(query, {"limit": limit, "offset": offset})
         books = self.hydrator.hydrate(records, Book, True, exclude)
 
         return books

--- a/Chapter11/booktracker/application/booktracker/blueprints/book/hydrator.py
+++ b/Chapter11/booktracker/application/booktracker/blueprints/book/hydrator.py
@@ -16,7 +16,9 @@ class BookHydrator(Hydrator):
         model: Type[T],
         exclude: Optional[List[str]] = None,
     ) -> T:
-        series = Series(**loads(record["series"])) if record["series"] else None
+        series = (
+            Series(**loads(record["series"])) if record["series"] else None
+        )
         kwargs = {
             **record,
             "author": Author(**loads(record["author"])),

--- a/Chapter11/booktracker/application/booktracker/blueprints/book/hydrator.py
+++ b/Chapter11/booktracker/application/booktracker/blueprints/book/hydrator.py
@@ -1,19 +1,20 @@
 from json import loads
-from typing import Any, List, Mapping, Optional, Type
+from typing import Any, List, Mapping, Optional, Type, TypeVar
 
 from booktracker.blueprints.author.model import Author
 from booktracker.blueprints.book.model import Series
 from booktracker.common.base_model import BaseModel
 from booktracker.common.dao.hydrator import Hydrator
 
+T = TypeVar("T", bound=BaseModel)
 
 class BookHydrator(Hydrator):
     def do_hydration(
         self,
         record: Mapping[str, Any],
-        model: Type[BaseModel],
+        model: Type[T],
         exclude: Optional[List[str]] = None,
-    ):
+    ) -> T:
         series = Series(**loads(record["series"])) if record["series"] else None
         kwargs = {
             **record,

--- a/Chapter11/booktracker/application/booktracker/blueprints/book/hydrator.py
+++ b/Chapter11/booktracker/application/booktracker/blueprints/book/hydrator.py
@@ -8,6 +8,7 @@ from booktracker.common.dao.hydrator import Hydrator
 
 T = TypeVar("T", bound=BaseModel)
 
+
 class BookHydrator(Hydrator):
     def do_hydration(
         self,

--- a/Chapter11/booktracker/application/booktracker/blueprints/book/view.py
+++ b/Chapter11/booktracker/application/booktracker/blueprints/book/view.py
@@ -2,16 +2,17 @@ from logging import getLogger
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 
 from asyncpg.exceptions import UniqueViolationError
-from booktracker.blueprints.author.executor import AuthorExecutor
-from booktracker.blueprints.user.executor import UserExecutor
-from booktracker.blueprints.user.model import User
-from booktracker.common.csrf import csrf_protected
-from booktracker.common.pagination import Pagination
 from sanic import Blueprint, Request, json
 from sanic.exceptions import NotFound
 from sanic.views import HTTPMethodView
 from sanic_ext import validate
 from sanic_jwt.decorators import inject_user, protected
+
+from booktracker.blueprints.author.executor import AuthorExecutor
+from booktracker.blueprints.user.executor import UserExecutor
+from booktracker.blueprints.user.model import User
+from booktracker.common.csrf import csrf_protected
+from booktracker.common.pagination import Pagination
 
 from .executor import BookExecutor, BookSeriesExecutor
 from .hydrator import BookHydrator

--- a/Chapter11/booktracker/application/booktracker/blueprints/book/view.py
+++ b/Chapter11/booktracker/application/booktracker/blueprints/book/view.py
@@ -37,17 +37,19 @@ class BookListView(HTTPMethodView, attach=bp):
         else:
             author = await author_executor.get_author_by_eid(eid=body.author)
 
+        series_id = None
         if body.series:
             if not body.series_is_eid:
                 series = await series_executor.create_book_series(name=body.series)
             else:
                 series = await series_executor.get_book_series_by_eid(eid=body.series)
+            series_id = series.series_id
 
         if not body.title_is_eid:
             book = await book_executor.create_book(
                 title=body.title,
                 author_id=author.author_id,
-                series_id=series.series_id if body.series else None,
+                series_id=series_id,
             )
         else:
             book = await book_executor.get_book_by_eid(eid=body.title)

--- a/Chapter11/booktracker/application/booktracker/blueprints/book/view.py
+++ b/Chapter11/booktracker/application/booktracker/blueprints/book/view.py
@@ -41,9 +41,13 @@ class BookListView(HTTPMethodView, attach=bp):
         series_id = None
         if body.series:
             if not body.series_is_eid:
-                series = await series_executor.create_book_series(name=body.series)
+                series = await series_executor.create_book_series(
+                    name=body.series
+                )
             else:
-                series = await series_executor.get_book_series_by_eid(eid=body.series)
+                series = await series_executor.get_book_series_by_eid(
+                    eid=body.series
+                )
             series_id = series.series_id
 
         if not body.title_is_eid:
@@ -96,7 +100,10 @@ class BookDetailsView(HTTPMethodView, attach=bp, uri="/<eid>"):
     @staticmethod
     @inject_user()
     async def get(
-        request: Request, eid: str, user: Optional[User], executor: BookExecutor
+        request: Request,
+        eid: str,
+        user: Optional[User],
+        executor: BookExecutor,
     ):
         # executor = BookExecutor(request.app.ctx.postgres, BookHydrator())
         getter: Callable[..., Awaitable[Book]] = executor.get_book_by_eid
@@ -115,7 +122,9 @@ class BookLoveView(HTTPMethodView, attach=bp, uri="/<eid>/love"):
     @csrf_protected
     async def put(request: Request, eid: str, user: User):
         executor = BookExecutor(request.app.ctx.postgres, BookHydrator())
-        await executor.update_toggle_book_is_loved(eid=eid, user_id=user.user_id)
+        await executor.update_toggle_book_is_loved(
+            eid=eid, user_id=user.user_id
+        )
         return json({"ok": True})
 
 
@@ -137,7 +146,9 @@ class BookSeriesListView(HTTPMethodView, attach=bp, uri="/series"):
     async def get(request: Request, pagination: Pagination):
         executor = BookSeriesExecutor(request.app.ctx.postgres)
         kwargs = {**pagination.to_dict()}
-        getter: Callable[..., Awaitable[List[Series]]] = executor.get_all_series
+        getter: Callable[
+            ..., Awaitable[List[Series]]
+        ] = executor.get_all_series
 
         if name := request.args.get("name"):
             kwargs["name"] = name

--- a/Chapter11/booktracker/application/booktracker/blueprints/frontend/reload.py
+++ b/Chapter11/booktracker/application/booktracker/blueprints/frontend/reload.py
@@ -39,7 +39,9 @@ async def file_reloaded() -> None:
 
 
 @livereload.websocket("/livereload")
-async def livereload_handler(request: Request, ws: WebsocketImplProtocol) -> None:
+async def livereload_handler(
+    request: Request, ws: WebsocketImplProtocol
+) -> None:
     reload_path = {
         "command": "reload",
         "path": str(request.app.config.UI_DIR / "public" / "index.html"),

--- a/Chapter11/booktracker/application/booktracker/blueprints/frontend/reload.py
+++ b/Chapter11/booktracker/application/booktracker/blueprints/frontend/reload.py
@@ -1,14 +1,13 @@
 from asyncio.subprocess import PIPE, create_subprocess_shell
 from logging import getLogger
-from typing import Any
 
 import ujson
+from sanic import Blueprint, HTTPResponse, Request, Sanic
+from sanic.response import file
 from sanic.server import AsyncioServer
 from sanic.server.websockets.impl import WebsocketImplProtocol
 
 from booktracker.common.log import setup_logging
-from sanic import Blueprint, HTTPResponse, Request, Sanic
-from sanic.response import file
 
 logger = getLogger("booktracker")
 livereload = Sanic("Livereload")

--- a/Chapter11/booktracker/application/booktracker/blueprints/frontend/reload.py
+++ b/Chapter11/booktracker/application/booktracker/blueprints/frontend/reload.py
@@ -82,7 +82,7 @@ def setup_livereload(bp: Blueprint) -> None:
             app.add_task(runner(livereload, app.ctx.livereload_server))
 
     @bp.before_server_stop
-    async def stop(app: Sanic, _: Any) -> None:
+    async def stop(app: Sanic, _) -> None:
         await app.ctx.livereload_server.close()
 
     @bp.before_server_start

--- a/Chapter11/booktracker/application/booktracker/blueprints/frontend/reload.py
+++ b/Chapter11/booktracker/application/booktracker/blueprints/frontend/reload.py
@@ -86,7 +86,7 @@ def setup_livereload(bp: Blueprint) -> None:
         await app.ctx.livereload_server.close()
 
     @bp.before_server_start
-    async def check_reloads(app: Sanic, _: Any) -> None:
+    async def check_reloads(app: Sanic, _) -> None:
         do_rebuild = False
         if reloaded := app.config.get("RELOADED_FILES"):
             reloaded = reloaded.split(",")

--- a/Chapter11/booktracker/application/booktracker/blueprints/frontend/reload.py
+++ b/Chapter11/booktracker/application/booktracker/blueprints/frontend/reload.py
@@ -72,7 +72,7 @@ def setup_livereload(bp: Blueprint) -> None:
     livereload.ctx.bp = bp
 
     @bp.before_server_start
-    async def start(app: Sanic, _: Any) -> None:
+    async def start(app: Sanic, _) -> None:
         global livereload
         livereload.config.UI_DIR = app.config.UI_DIR
         app.ctx.livereload_server = await livereload.create_server(

--- a/Chapter11/booktracker/application/booktracker/blueprints/frontend/reload.py
+++ b/Chapter11/booktracker/application/booktracker/blueprints/frontend/reload.py
@@ -1,9 +1,13 @@
 from asyncio.subprocess import PIPE, create_subprocess_shell
 from logging import getLogger
+from typing import Any
 
 import ujson
+from sanic.server import AsyncioServer
+from sanic.server.websockets.impl import WebsocketImplProtocol
+
 from booktracker.common.log import setup_logging
-from sanic import Blueprint, Request, Sanic
+from sanic import Blueprint, HTTPResponse, Request, Sanic
 from sanic.response import file
 
 logger = getLogger("booktracker")
@@ -21,22 +25,22 @@ HELLO = {
 
 
 @livereload.get("/livereload.js")
-async def livereload_js(request: Request):
+async def livereload_js(request: Request) -> HTTPResponse:
     return await file(request.app.config.UI_DIR / "public" / "livereload.js")
 
 
 @livereload.signal("http.routing.after")
-async def after_routing(**_):
+async def after_routing(**_) -> None:
     ...
 
 
 @livereload.signal("watchdog.file.reload")
-async def file_reloaded():
+async def file_reloaded() -> None:
     ...
 
 
 @livereload.websocket("/livereload")
-async def livereload_handler(request, ws):
+async def livereload_handler(request: Request, ws: WebsocketImplProtocol) -> None:
     reload_path = {
         "command": "reload",
         "path": str(request.app.config.UI_DIR / "public" / "index.html"),
@@ -50,7 +54,7 @@ async def livereload_handler(request, ws):
         await ws.send(ujson.dumps(reload_path))
 
 
-async def runner(app: Sanic, app_server):
+async def runner(app: Sanic, app_server: AsyncioServer) -> None:
     app.is_running = True
     try:
         app.signalize()
@@ -63,24 +67,26 @@ async def runner(app: Sanic, app_server):
         app.is_stopping = True
 
 
-def setup_livereload(bp: Blueprint):
+def setup_livereload(bp: Blueprint) -> None:
+    global livereload
     livereload.ctx.bp = bp
 
     @bp.before_server_start
-    async def start(app, _):
+    async def start(app: Sanic, _: Any) -> None:
         global livereload
         livereload.config.UI_DIR = app.config.UI_DIR
         app.ctx.livereload_server = await livereload.create_server(
             host="0.0.0.0", port=35729, return_asyncio_server=True
         )
-        app.add_task(runner(livereload, app.ctx.livereload_server))
+        if app.ctx.livereload_server is not None:
+            app.add_task(runner(livereload, app.ctx.livereload_server))
 
     @bp.before_server_stop
-    async def stop(app, _):
+    async def stop(app: Sanic, _: Any) -> None:
         await app.ctx.livereload_server.close()
 
     @bp.before_server_start
-    async def check_reloads(app, _):
+    async def check_reloads(app: Sanic, _: Any) -> None:
         do_rebuild = False
         if reloaded := app.config.get("RELOADED_FILES"):
             reloaded = reloaded.split(",")
@@ -100,11 +106,12 @@ def setup_livereload(bp: Blueprint):
                 cwd=app.config.UI_DIR,
             )
 
-            while True:
-                message = await rebuild.stdout.readline()
-                if not message:
-                    break
-                output = message.decode("ascii").rstrip()
-                logger.info(f"[reload] {output}")
+            if rebuild.stdout is not None:
+                while True:
+                    message = await rebuild.stdout.readline()
+                    if not message:
+                        break
+                    output = message.decode("ascii").rstrip()
+                    logger.info(f"[reload] {output}")
 
             await livereload.dispatch("watchdog.file.reload")

--- a/Chapter11/booktracker/application/booktracker/blueprints/frontend/view.py
+++ b/Chapter11/booktracker/application/booktracker/blueprints/frontend/view.py
@@ -1,7 +1,7 @@
 from logging import getLogger
 from pathlib import Path
 
-from sanic import Blueprint, Request
+from sanic import Blueprint, HTTPResponse, Request
 from sanic.response import file
 
 from .reload import setup_livereload
@@ -12,7 +12,7 @@ setup_livereload(bp)
 
 
 @bp.get("/<path:path>")
-async def index(request: Request, path: str):
+async def index(request: Request, path: str) -> HTTPResponse:
     base: Path = request.app.config.UI_DIR / "public"
     requested_path = base / path
     logger.debug(f"Checking for {requested_path}")

--- a/Chapter11/booktracker/application/booktracker/common/auth/endpoint.py
+++ b/Chapter11/booktracker/application/booktracker/common/auth/endpoint.py
@@ -18,7 +18,10 @@ class GitHubOAuthLogin(BaseEndpoint):
 
         response = redirect(url)
 
-        if "csrf_token" not in request.cookies or "ref_token" not in request.cookies:
+        if (
+            "csrf_token" not in request.cookies
+            or "ref_token" not in request.cookies
+        ):
             ref, token = generate_csrf(
                 request.app.config.CSRF_SECRET,
                 request.app.config.CSRF_REF_LENGTH,

--- a/Chapter11/booktracker/application/booktracker/common/auth/endpoint.py
+++ b/Chapter11/booktracker/application/booktracker/common/auth/endpoint.py
@@ -1,10 +1,11 @@
 from typing import Optional
 
-from booktracker.common.cookie import set_cookie
-from booktracker.common.csrf import generate_csrf
 from sanic import HTTPResponse, Request
 from sanic.response import redirect
 from sanic_jwt import BaseEndpoint
+
+from booktracker.common.cookie import set_cookie
+from booktracker.common.csrf import generate_csrf
 
 
 class GitHubOAuthLogin(BaseEndpoint):

--- a/Chapter11/booktracker/application/booktracker/common/auth/endpoint.py
+++ b/Chapter11/booktracker/application/booktracker/common/auth/endpoint.py
@@ -1,29 +1,29 @@
+from typing import Optional
+
 from booktracker.common.cookie import set_cookie
 from booktracker.common.csrf import generate_csrf
-from sanic import Request
+from sanic import HTTPResponse, Request
 from sanic.response import redirect
 from sanic_jwt import BaseEndpoint
 
 
 class GitHubOAuthLogin(BaseEndpoint):
     @staticmethod
-    async def get(request: Request):
+    async def get(request: Request) -> Optional[HTTPResponse]:
         url = (
             "https://github.com/login/oauth/authorize?scope=read:user"
             f"&client_id={request.app.config.GITHUB_OAUTH_CLIENT_ID}"
         )
 
-        if (
-            "csrf_token" not in request.cookies
-            or "ref_token" not in request.cookies
-        ):
+        response = redirect(url)
+
+        if "csrf_token" not in request.cookies or "ref_token" not in request.cookies:
             ref, token = generate_csrf(
                 request.app.config.CSRF_SECRET,
                 request.app.config.CSRF_REF_LENGTH,
                 request.app.config.CSRF_REF_PADDING,
             )
 
-            response = redirect(url)
             set_cookie(
                 response=response,
                 domain="localhost",

--- a/Chapter11/booktracker/application/booktracker/common/auth/handler.py
+++ b/Chapter11/booktracker/application/booktracker/common/auth/handler.py
@@ -3,12 +3,13 @@ from typing import Any, Dict, Optional
 
 import httpx
 from aioredis import Redis
-from booktracker.blueprints.user.executor import UserExecutor
 from sanic import Request
 from sanic.exceptions import NotFound, Unauthorized
 
-from .model import RefreshTokenKey
+from booktracker.blueprints.user.executor import UserExecutor
+
 from ...blueprints.user.model import User
+from .model import RefreshTokenKey
 
 logger = getLogger("booktracker")
 

--- a/Chapter11/booktracker/application/booktracker/common/auth/handler.py
+++ b/Chapter11/booktracker/application/booktracker/common/auth/handler.py
@@ -55,7 +55,9 @@ async def authenticate(request: Request) -> User:
     async with httpx.AsyncClient() as session:
         response = await session.get(
             "https://api.github.com/user",
-            headers={"Authorization": f"token {response.json()['access_token']}"},
+            headers={
+                "Authorization": f"token {response.json()['access_token']}"
+            },
         )
 
     if b"error" in response.content or response.status_code != 200:
@@ -79,7 +81,9 @@ async def authenticate(request: Request) -> User:
     return user
 
 
-async def retrieve_user(request: Request, payload: Dict[str, Any]) -> Optional[User]:
+async def retrieve_user(
+    request: Request, payload: Dict[str, Any]
+) -> Optional[User]:
     if not payload:
         return None
 
@@ -87,7 +91,9 @@ async def retrieve_user(request: Request, payload: Dict[str, Any]) -> Optional[U
     return await executor.get_by_eid(eid=payload["eid"])
 
 
-async def payload_extender(payload: Dict[str, Any], user: User) -> Dict[str, Any]:
+async def payload_extender(
+    payload: Dict[str, Any], user: User
+) -> Dict[str, Any]:
     payload.update({"user": user.to_dict()})
     return payload
 

--- a/Chapter11/booktracker/application/booktracker/common/auth/startup.py
+++ b/Chapter11/booktracker/application/booktracker/common/auth/startup.py
@@ -11,7 +11,7 @@ from .handler import (
 )
 
 
-def setup_auth(app: Sanic):
+def setup_auth(app: Sanic) -> None:
     Initialize(
         app,
         url_prefix="/api/v1/auth",

--- a/Chapter11/booktracker/application/booktracker/common/base_model.py
+++ b/Chapter11/booktracker/application/booktracker/common/base_model.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field, fields
 from datetime import date, datetime
 from enum import Enum
 from inspect import getmembers
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 from uuid import UUID
 
 import ujson
@@ -29,7 +29,7 @@ class Config:
 def pkdataclass(decorated_class, *args, **kwargs):
     def wrapper(cls):
         orig = getattr(cls, "__init__")
-        derived = dataclass(cls, *args, **kwargs)
+        derived = dataclass(cls, *args, **kwargs)  # noqa
         setattr(derived, "__default_init__", derived.__init__)
         setattr(derived, "__init__", orig)
         return derived
@@ -67,7 +67,7 @@ class BaseModel(metaclass=BaseModelMeta):
             kwargs[self.__config__.pk_field] = None
         self.__default_init__(*args, **kwargs)  # type: ignore
 
-    def __json__(self):
+    def __json__(self) -> str:
         return ujson.dumps(self.to_dict(clean=True))
 
     @property
@@ -80,11 +80,11 @@ class BaseModel(metaclass=BaseModelMeta):
         clean: bool = False,
         include_null: Optional[bool] = None,
         cascade: bool = True,
-    ):
+    ) -> Dict[str, Any]:
         if include_null is not None:
             self.set_state("include_null", include_null, cascade)
         output = {}
-        for fld in fields(self):
+        for fld in fields(self):  # noqa
             value = getattr(self, fld.name)
             if isinstance(value, BaseModel):
                 value = value.to_dict(clean=clean)
@@ -107,7 +107,7 @@ class BaseModel(metaclass=BaseModelMeta):
         return isinstance(obj, BaseModel)
 
     @staticmethod
-    def _clean(value):
+    def _clean(value: Any) -> Any:
         if isinstance(value, (date, datetime)):
             return value.isoformat()
         elif isinstance(value, UUID):

--- a/Chapter11/booktracker/application/booktracker/common/cache.py
+++ b/Chapter11/booktracker/application/booktracker/common/cache.py
@@ -43,7 +43,9 @@ async def get_cached_response(
     return {}
 
 
-def cache_response(build_key: str, exp: int = 60 * 60 * 72) -> Callable[[FuncT], FuncT]:
+def cache_response(
+    build_key: str, exp: int = 60 * 60 * 72
+) -> Callable[[FuncT], FuncT]:
     """
     Cache an expensive response in Redis for quicker retrieval on subsequent
     calls to the endpoint
@@ -57,7 +59,9 @@ def cache_response(build_key: str, exp: int = 60 * 60 * 72) -> Callable[[FuncT],
             cache: Redis = request.app.ctx.redis
             key = make_key(build_key, request)
 
-            if cached_response := await get_cached_response(request, cache, key):
+            if cached_response := await get_cached_response(
+                request, cache, key
+            ):
                 response = raw(**cached_response)
             else:
                 response = await f(request, *handler_args, **handler_kwargs)

--- a/Chapter11/booktracker/application/booktracker/common/cache.py
+++ b/Chapter11/booktracker/application/booktracker/common/cache.py
@@ -1,12 +1,14 @@
 from functools import wraps
-from typing import Dict, Union
+from typing import Any, Callable, Coroutine, Dict, Union, cast
 
 from aioredis.client import Redis
 from sanic import Request
 from sanic.response import HTTPResponse, raw
 
+FuncT = Callable[..., Coroutine[None, None, HTTPResponse]]
 
-def make_key(build_key, request):
+
+def make_key(build_key: str, request: Request) -> str:
     return ":".join(["cached-response", build_key, request.name])
 
 
@@ -15,7 +17,7 @@ async def set_cached_response(
     redis: Redis,
     key: str,
     exp: int,
-):
+) -> None:
     await redis.hmset(
         key,
         {
@@ -29,7 +31,7 @@ async def set_cached_response(
 
 async def get_cached_response(
     request: Request, redis: Redis, key: str
-) -> Dict[str, Union[str, int]]:
+) -> Dict[str, Any]:
     exists = await redis.hgetall(key)
     if exists and not request.args.get("refresh"):
         cached_response = {
@@ -41,21 +43,21 @@ async def get_cached_response(
     return {}
 
 
-def cache_response(build_key, exp: int = 60 * 60 * 72):
+def cache_response(build_key: str, exp: int = 60 * 60 * 72) -> Callable[[FuncT], FuncT]:
     """
     Cache an expensive response in Redis for quicker retrieval on subsequent
     calls to the endpoint
     """
 
-    def decorator(f):
+    def decorator(f: FuncT) -> FuncT:
         @wraps(f)
-        async def decorated_function(request, *handler_args, **handler_kwargs):
+        async def decorated_function(
+            request: Request, *handler_args: Any, **handler_kwargs: Any
+        ) -> HTTPResponse:
             cache: Redis = request.app.ctx.redis
             key = make_key(build_key, request)
 
-            if cached_response := await get_cached_response(
-                request, cache, key
-            ):
+            if cached_response := await get_cached_response(request, cache, key):
                 response = raw(**cached_response)
             else:
                 response = await f(request, *handler_args, **handler_kwargs)
@@ -63,6 +65,6 @@ def cache_response(build_key, exp: int = 60 * 60 * 72):
 
             return response
 
-        return decorated_function
+        return cast(FuncT, decorated_function)
 
     return decorator

--- a/Chapter11/booktracker/application/booktracker/common/cookie.py
+++ b/Chapter11/booktracker/application/booktracker/common/cookie.py
@@ -1,17 +1,19 @@
 from datetime import datetime
 from typing import Optional
 
+from sanic import HTTPResponse
+
 
 def set_cookie(
-    response,
-    key,
-    value,
-    httponly=False,
-    samesite="lax",
+    response: HTTPResponse,
+    key: str,
+    value: str,
+    httponly: bool = False,
+    samesite: str = "lax",
     domain: Optional[str] = None,
     exp: Optional[datetime] = None,
     secure: bool = True,
-):
+) -> None:
     response.cookies[key] = value
     response.cookies[key]["httponly"] = httponly
     response.cookies[key]["path"] = "/"

--- a/Chapter11/booktracker/application/booktracker/common/csrf.py
+++ b/Chapter11/booktracker/application/booktracker/common/csrf.py
@@ -2,11 +2,14 @@ import os
 from base64 import b64decode, b64encode
 from functools import wraps
 from inspect import isawaitable
+from typing import Any, Callable, Coroutine, Literal, Optional, Tuple, Union, cast
 
 from booktracker.common.cookie import set_cookie
 from cryptography.fernet import Fernet, InvalidToken
 from sanic import HTTPResponse, Request, Sanic
 from sanic.exceptions import Forbidden
+
+FuncT = Callable[..., Union[Coroutine[None, None, HTTPResponse], HTTPResponse]]
 
 
 class CSRFFailure(Forbidden):
@@ -14,10 +17,10 @@ class CSRFFailure(Forbidden):
     quiet = False
 
 
-def csrf_protected(func):
-    def decorator(f):
+def csrf_protected(func: FuncT) -> FuncT:
+    def decorator(f: FuncT) -> FuncT:
         @wraps(f)
-        async def decorated_function(request, *args, **kwargs):
+        async def decorated_function(request: Request, *args: Any, **kwargs: Any) -> HTTPResponse:
 
             origin = request.headers.get("origin")
             if request.ctx.from_browser and (
@@ -31,14 +34,14 @@ def csrf_protected(func):
             if isawaitable(response):
                 response = await response
 
-            return response
+            return cast(HTTPResponse, response)
 
-        return decorated_function
+        return cast(FuncT, decorated_function)
 
     return decorator(func)
 
 
-def setup_csrf(app: Sanic):
+def setup_csrf(app: Sanic) -> None:
     @app.on_request
     async def check_request(request: Request):
         request.ctx.from_browser = (
@@ -47,12 +50,10 @@ def setup_csrf(app: Sanic):
 
     @app.on_response
     async def mark_browser(_, response: HTTPResponse):
-        set_cookie(
-            response=response, key="browser_check", value="1", httponly=True
-        )
+        set_cookie(response=response, key="browser_check", value="1", httponly=True)
 
 
-def generate_csrf(secret, ref_length, padding):
+def generate_csrf(secret: str, ref_length: int, padding: int) -> Tuple[str, str]:
     cipher = Fernet(secret)
     ref = os.urandom(ref_length)
     pad = os.urandom(padding)
@@ -61,7 +62,9 @@ def generate_csrf(secret, ref_length, padding):
     return ref.hex(), b64encode(pad + pretoken).decode("utf-8")
 
 
-def verify_csrf(secret, padding, ref, token):
+def verify_csrf(
+    secret: str, padding: int, ref: Optional[str], token: Optional[str]
+) -> None:
     if not ref or not token:
         raise InvalidToken("Token is incorrect")
 
@@ -74,7 +77,7 @@ def verify_csrf(secret, padding, ref, token):
         raise InvalidToken("Token is incorrect")
 
 
-def csrf_check(request: Request):
+def csrf_check(request: Request) -> Literal[True]:
     csrf_header = request.headers.get("x-xsrf-token")
     csrf_cookie = request.cookies.get("csrf_token")
     ref_token = request.cookies.get("ref_token")

--- a/Chapter11/booktracker/application/booktracker/common/csrf.py
+++ b/Chapter11/booktracker/application/booktracker/common/csrf.py
@@ -2,7 +2,16 @@ import os
 from base64 import b64decode, b64encode
 from functools import wraps
 from inspect import isawaitable
-from typing import Any, Callable, Coroutine, Literal, Optional, Tuple, Union, cast
+from typing import (
+    Any,
+    Callable,
+    Coroutine,
+    Literal,
+    Optional,
+    Tuple,
+    Union,
+    cast,
+)
 
 from cryptography.fernet import Fernet, InvalidToken
 from sanic import HTTPResponse, Request, Sanic
@@ -53,10 +62,14 @@ def setup_csrf(app: Sanic) -> None:
 
     @app.on_response
     async def mark_browser(_, response: HTTPResponse):
-        set_cookie(response=response, key="browser_check", value="1", httponly=True)
+        set_cookie(
+            response=response, key="browser_check", value="1", httponly=True
+        )
 
 
-def generate_csrf(secret: str, ref_length: int, padding: int) -> Tuple[str, str]:
+def generate_csrf(
+    secret: str, ref_length: int, padding: int
+) -> Tuple[str, str]:
     cipher = Fernet(secret)
     ref = os.urandom(ref_length)
     pad = os.urandom(padding)

--- a/Chapter11/booktracker/application/booktracker/common/csrf.py
+++ b/Chapter11/booktracker/application/booktracker/common/csrf.py
@@ -4,10 +4,11 @@ from functools import wraps
 from inspect import isawaitable
 from typing import Any, Callable, Coroutine, Literal, Optional, Tuple, Union, cast
 
-from booktracker.common.cookie import set_cookie
 from cryptography.fernet import Fernet, InvalidToken
 from sanic import HTTPResponse, Request, Sanic
 from sanic.exceptions import Forbidden
+
+from booktracker.common.cookie import set_cookie
 
 FuncT = Callable[..., Union[Coroutine[None, None, HTTPResponse], HTTPResponse]]
 
@@ -20,7 +21,9 @@ class CSRFFailure(Forbidden):
 def csrf_protected(func: FuncT) -> FuncT:
     def decorator(f: FuncT) -> FuncT:
         @wraps(f)
-        async def decorated_function(request: Request, *args: Any, **kwargs: Any) -> HTTPResponse:
+        async def decorated_function(
+            request: Request, *args: Any, **kwargs: Any
+        ) -> HTTPResponse:
 
             origin = request.headers.get("origin")
             if request.ctx.from_browser and (

--- a/Chapter11/booktracker/application/booktracker/common/dao/decorator.py
+++ b/Chapter11/booktracker/application/booktracker/common/dao/decorator.py
@@ -30,7 +30,9 @@ if TYPE_CHECKING:
 logger = getLogger("booktracker")
 
 ModelT = TypeVar("ModelT", bound=BaseModel)
-FuncT = Callable[..., Coroutine[None, None, Optional[Union[ModelT, List[ModelT]]]]]
+FuncT = Callable[
+    ..., Coroutine[None, None, Optional[Union[ModelT, List[ModelT]]]]
+]
 RecordT = Mapping[str, Any]
 ExcludeT = Optional[List[str]]
 
@@ -100,10 +102,16 @@ def execute(func: FuncT[ModelT]) -> FuncT[ModelT]:
                     raise NotFound(f"Did not find {model.__name__}")
                 elif not results and is_create:
                     results = values
-                elif is_create and isinstance(results, dict) and len(results) == 1:
+                elif (
+                    is_create
+                    and isinstance(results, dict)
+                    and len(results) == 1
+                ):
                     results.update(values)
 
-                return self.hydrator.hydrate(results, model, as_list, exclude)  # noqa
+                return self.hydrator.hydrate(
+                    results, model, as_list, exclude
+                )  # noqa
 
             return await f(*args, **kwargs)
 

--- a/Chapter11/booktracker/application/booktracker/common/dao/decorator.py
+++ b/Chapter11/booktracker/application/booktracker/common/dao/decorator.py
@@ -1,15 +1,21 @@
 from functools import wraps
 from inspect import getsourcelines, signature
 from logging import getLogger
-from typing import get_args, get_origin
+from typing import Any, Callable, Coroutine, List, Mapping, Optional, Type, TypeVar, Union, cast, get_args, get_origin
 
+from booktracker.common.base_model import BaseModel
 from booktracker.common.eid import generate
 from sanic.exceptions import NotFound, SanicException
 
 logger = getLogger("booktracker")
 
+ModelT = TypeVar("ModelT", bound=BaseModel)
+FuncT = Callable[..., Coroutine[None, None, Optional[Union[ModelT, List[ModelT]]]]]
+RecordT = Mapping[str, Any]
+ExcludeT = Optional[List[str]]
 
-def execute(func):
+
+def execute(func: FuncT[ModelT]) -> FuncT[ModelT]:
     """
     Responsible for executing a DB query and passing the result off to a
     hydrator.
@@ -18,6 +24,7 @@ def execute(func):
     we should automatically execute the in memory SQL, and passing the results
     off to the base Hydrator.
     """
+    from booktracker.common.dao.executor import BaseExecutor
     sig = signature(func)
     src = getsourcelines(func)
 
@@ -25,14 +32,14 @@ def execute(func):
     # - Make sure that this is the ONLY part of the source, and also
     #   accept methods that only have a docstring and no code.
     auto_exec = src[0][-1].strip() in ("...", "pass")
-    model = sig.return_annotation
-    as_list = False
-    is_create = func.__name__.startswith("create_")
+    model: Type[ModelT] = sig.return_annotation
+    as_list: bool = False
+    is_create: bool = func.__name__.startswith("create_")
 
     if model is not None and (origin := get_origin(model)):
         as_list = bool(origin is list)
         if not as_list:
-            return SanicException(
+            raise SanicException(
                 f"{func} must return either a model or a list of models. "
                 "eg. -> Foo or List[Foo]"
             )
@@ -40,28 +47,28 @@ def execute(func):
 
     name = func.__name__
 
-    def decorator(f):
+    def decorator(f: FuncT[ModelT]) -> FuncT[ModelT]:
         @wraps(f)
-        async def decorated_function(*args, **kwargs):
+        async def decorated_function(*args: Any, **kwargs: Any) -> Optional[Union[ModelT, List[ModelT]]]:
             if is_create and "eid" in sig.parameters.keys():
                 kwargs["eid"] = generate(width=24)
 
             if auto_exec:
-                self = args[0]
+                self: BaseExecutor = args[0]
                 query = self._queries[name]
                 method_name = "fetch_all" if as_list else "fetch_one"
                 bound = sig.bind(*args, **kwargs)
                 bound.apply_defaults()
                 values = {**bound.arguments}
                 values.pop("self")
-                exclude = values.pop("exclude", None)
-                results = await getattr(self.db, method_name)(
+                exclude: ExcludeT = values.pop("exclude", None)
+                results: Union[RecordT, List[RecordT]] = await getattr(self.db, method_name)(
                     query=query, values=values
                 )
 
                 if results:
                     if isinstance(results, list):
-                        results = list(map(dict, results))
+                        results = [dict(r) for r in results]
                     else:
                         results = dict(results)
 
@@ -72,13 +79,13 @@ def execute(func):
                     raise NotFound(f"Did not find {model.__name__}")
                 elif not results and is_create:
                     results = values
-                elif is_create and len(results) == 1:
+                elif is_create and isinstance(results, dict) and len(results) == 1:
                     results.update(values)
 
-                return self.hydrator.hydrate(results, model, as_list, exclude)
+                return self.hydrator.hydrate(results, model, as_list, exclude)  # noqa
 
             return await f(*args, **kwargs)
 
-        return decorated_function
+        return cast(FuncT[ModelT], decorated_function)
 
     return decorator(func)

--- a/Chapter11/booktracker/application/booktracker/common/dao/executor.py
+++ b/Chapter11/booktracker/application/booktracker/common/dao/executor.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from inspect import getmembers, getmodule, isfunction
 from pathlib import Path
-from typing import Dict, Optional, Set, Type
+from typing import Any, Dict, Optional, Set, Type
 
 from databases import Database
 from sanic.exceptions import SanicException
@@ -56,7 +56,7 @@ class BaseExecutor:
                 setattr(executor, name, execute(func))
 
     @staticmethod
-    def isoperation(obj):
+    def isoperation(obj: Any) -> bool:
         """Check if the object is a method that starts with get_ or create_"""
         if isfunction(obj):
             return (
@@ -67,6 +67,6 @@ class BaseExecutor:
         return False
 
     @staticmethod
-    def load_sql(path: Path):
+    def load_sql(path: Path) -> str:
         with open(path, "r") as f:
             return f.read()

--- a/Chapter11/booktracker/application/booktracker/common/dao/executor.py
+++ b/Chapter11/booktracker/application/booktracker/common/dao/executor.py
@@ -21,7 +21,9 @@ class BaseExecutor:
     _fallback_hydrator: Hydrator
     db: Database
 
-    def __init__(self, db: Database, hydrator: Optional[Hydrator] = None) -> None:
+    def __init__(
+        self, db: Database, hydrator: Optional[Hydrator] = None
+    ) -> None:
         self.db = db
         self._hydrator = hydrator
 

--- a/Chapter11/booktracker/application/booktracker/common/dao/executor.py
+++ b/Chapter11/booktracker/application/booktracker/common/dao/executor.py
@@ -21,9 +21,7 @@ class BaseExecutor:
     _fallback_hydrator: Hydrator
     db: Database
 
-    def __init__(
-        self, db: Database, hydrator: Optional[Hydrator] = None
-    ) -> None:
+    def __init__(self, db: Database, hydrator: Optional[Hydrator] = None) -> None:
         self.db = db
         self._hydrator = hydrator
 

--- a/Chapter11/booktracker/application/booktracker/common/dao/hydrator.py
+++ b/Chapter11/booktracker/application/booktracker/common/dao/hydrator.py
@@ -1,4 +1,14 @@
-from typing import Any, List, Literal, Mapping, Optional, Type, TypeVar, Union, overload
+from typing import (
+    Any,
+    List,
+    Literal,
+    Mapping,
+    Optional,
+    Type,
+    TypeVar,
+    Union,
+    overload,
+)
 
 from booktracker.common.base_model import BaseModel
 
@@ -44,7 +54,9 @@ class Hydrator:
             record = [record] if not isinstance(record, list) else record
             return [self.do_hydration(r, model, exclude) for r in record]
         if isinstance(record, list):
-            raise TypeError("Unexpectedly found multiple records while hydrating")
+            raise TypeError(
+                "Unexpectedly found multiple records while hydrating"
+            )
         return self.do_hydration(record, model, exclude)
 
     def do_hydration(

--- a/Chapter11/booktracker/application/booktracker/common/dao/hydrator.py
+++ b/Chapter11/booktracker/application/booktracker/common/dao/hydrator.py
@@ -1,6 +1,10 @@
-from typing import Any, List, Mapping, Optional, Type, Union
+from typing import Any, List, Literal, Mapping, Optional, Type, TypeVar, Union, overload
 
 from booktracker.common.base_model import BaseModel
+
+ModelT = TypeVar("ModelT", bound=BaseModel)
+RecordT = Mapping[str, Any]
+ExcludeT = Optional[List[str]]
 
 
 class Hydrator:
@@ -9,28 +13,47 @@ class Hydrator:
     mainly be used for converting from DB results to Python objects.
     """
 
+    @overload
     def hydrate(
         self,
-        record: Union[Mapping[str, Any], List[Mapping[str, Any]]],
-        model: Type[BaseModel],
+        record: RecordT,
+        model: Type[ModelT],
+        as_list: Literal[False],
+        exclude: ExcludeT = None,
+    ) -> ModelT:
+        ...
+
+    @overload
+    def hydrate(
+        self,
+        record: List[RecordT],
+        model: Type[ModelT],
+        as_list: Literal[True],
+        exclude: ExcludeT = None,
+    ) -> List[ModelT]:
+        ...
+
+    def hydrate(
+        self,
+        record: Union[RecordT, List[RecordT]],
+        model: Type[ModelT],
         as_list: bool,
-        exclude: Optional[List[str]] = None,
-    ):
-        if as_list and isinstance(record, list):
+        exclude: ExcludeT = None,
+    ) -> Union[ModelT, List[ModelT]]:
+        if as_list:
+            record = [record] if not isinstance(record, list) else record
             return [self.do_hydration(r, model, exclude) for r in record]
         if isinstance(record, list):
-            raise TypeError(
-                "Unexpectedly found multiple records while hydrating"
-            )
+            raise TypeError("Unexpectedly found multiple records while hydrating")
         return self.do_hydration(record, model, exclude)
 
     def do_hydration(
         self,
-        record: Mapping[str, Any],
-        model: Type[BaseModel],
-        exclude: Optional[List[str]] = None,
-    ):
-        obj = model(**record)  # type: ignore
+        record: RecordT,
+        model: Type[ModelT],
+        exclude: ExcludeT = None,
+    ) -> ModelT:
+        obj = model(**record)
         if exclude:
             obj.__state__.exclude = exclude
         return obj

--- a/Chapter11/booktracker/application/booktracker/common/eid.py
+++ b/Chapter11/booktracker/application/booktracker/common/eid.py
@@ -5,7 +5,7 @@ REQUEST_ID_ALPHABET = ascii_letters + digits
 REQUEST_ID_ALPHABET_LENGTH = len(REQUEST_ID_ALPHABET)
 
 
-def generate(width: int = 0, fillchar: str = "x"):
+def generate(width: int = 0, fillchar: str = "x") -> str:
     """
     Generate a UUID and make is smaller
     """

--- a/Chapter11/booktracker/application/booktracker/common/pagination.py
+++ b/Chapter11/booktracker/application/booktracker/common/pagination.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
+
 from dataclasses import dataclass, field
 
-from booktracker.common.base_model import BaseModel
 from sanic import Request, Sanic
+
+from booktracker.common.base_model import BaseModel
 
 
 @dataclass

--- a/Chapter11/booktracker/application/booktracker/common/pagination.py
+++ b/Chapter11/booktracker/application/booktracker/common/pagination.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass, field
 
 from booktracker.common.base_model import BaseModel
@@ -10,7 +11,7 @@ class Pagination(BaseModel):
     offset: int = field(default=0)
 
     @staticmethod
-    async def from_request(request: Request):
+    async def from_request(request: Request) -> Pagination:
         args = {
             key: int(value)
             for key in ("limit", "offset")
@@ -19,7 +20,7 @@ class Pagination(BaseModel):
         return Pagination(**args)
 
 
-def setup_pagination(app: Sanic):
+def setup_pagination(app: Sanic) -> None:
     @app.before_server_start
     async def setup_pagination(app: Sanic, _):
         app.ext.injection(Pagination, Pagination.from_request)

--- a/Chapter11/booktracker/application/booktracker/middleware/request_context.py
+++ b/Chapter11/booktracker/application/booktracker/middleware/request_context.py
@@ -7,7 +7,7 @@ app = Sanic.get_app("BooktrackerApp")
 
 
 @app.after_server_start
-async def setup_request_context(app: Sanic, _: Any) -> None:
+async def setup_request_context(app: Sanic, _) -> None:
     app.ctx.request = ContextVar("request")
 
 

--- a/Chapter11/booktracker/application/booktracker/middleware/request_context.py
+++ b/Chapter11/booktracker/application/booktracker/middleware/request_context.py
@@ -1,4 +1,5 @@
 from contextvars import ContextVar
+from typing import Any
 
 from sanic import Request, Sanic
 
@@ -6,10 +7,10 @@ app = Sanic.get_app("BooktrackerApp")
 
 
 @app.after_server_start
-async def setup_request_context(app, _):
+async def setup_request_context(app: Sanic, _: Any) -> None:
     app.ctx.request = ContextVar("request")
 
 
 @app.on_request
-async def attach_request(request: Request):
+async def attach_request(request: Request) -> None:
     request.app.ctx.request.set(request)

--- a/Chapter11/booktracker/application/booktracker/server.py
+++ b/Chapter11/booktracker/application/booktracker/server.py
@@ -4,8 +4,8 @@ from typing import Optional, Sequence, Tuple
 from sanic import Sanic
 
 # Modules imported here should NOT have a Sanic.get_app() call in the global
-# scope. Doing so will cause a circular import. Therefore, we progromatically
-# import those modules inside of the create_app() factory.
+# scope. Doing so will cause a circular import. Therefore, we programmatically
+# import those modules inside the create_app() factory.
 from booktracker.common.auth.startup import setup_auth
 from booktracker.common.csrf import setup_csrf
 from booktracker.common.log import setup_logging
@@ -27,7 +27,7 @@ def create_app(module_names: Optional[Sequence[str]] = None) -> Sanic:
     application together. In most use cases, running the application will be
     done will a None value for module_names. Therefore, we provide a default
     list. This provides flexibility when unit testing the application. The main
-    purpose for this pattern is to avoide import issues. This should be the
+    purpose for this pattern is to avoid import issues. This should be the
     first thing that is called.
     """
     if module_names is None:

--- a/Chapter11/booktracker/application/booktracker/worker/module.py
+++ b/Chapter11/booktracker/application/booktracker/worker/module.py
@@ -3,7 +3,7 @@ from importlib import import_module
 from sanic import Sanic
 
 
-def setup_modules(app: Sanic, *module_names: str):
+def setup_modules(app: Sanic, *module_names: str) -> None:
     """
     Load some modules
     """

--- a/Chapter11/booktracker/application/booktracker/worker/postgres.py
+++ b/Chapter11/booktracker/application/booktracker/worker/postgres.py
@@ -1,15 +1,14 @@
-from typing import Any
+from databases import Database
+from sanic import Sanic
 
 from booktracker.common.dao.executor import BaseExecutor
 from booktracker.common.dao.hydrator import Hydrator
-from databases import Database
-from sanic import Sanic
 
 app = Sanic.get_app("BooktrackerApp")
 
 
 @app.before_server_start
-async def setup_postgres(app: Sanic, _: Any) -> None:
+async def setup_postgres(app: Sanic, _) -> None:
     app.ctx.postgres = Database(
         app.config.POSTGRES_DSN,
         min_size=app.config.POSTGRES_MIN,
@@ -18,15 +17,15 @@ async def setup_postgres(app: Sanic, _: Any) -> None:
 
 
 @app.after_server_start
-async def connect_postgres(app: Sanic, _: Any) -> None:
+async def connect_postgres(app: Sanic, _) -> None:
     await app.ctx.postgres.connect()
 
 
 @app.after_server_start
-async def load_sql(app: Sanic, _: Any) -> None:
+async def load_sql(app: Sanic, _) -> None:
     BaseExecutor.load(Hydrator())
 
 
 @app.after_server_stop
-async def shutdown_postgres(app: Sanic, _: Any) -> None:
+async def shutdown_postgres(app: Sanic, _) -> None:
     await app.ctx.postgres.disconnect()

--- a/Chapter11/booktracker/application/booktracker/worker/postgres.py
+++ b/Chapter11/booktracker/application/booktracker/worker/postgres.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from booktracker.common.dao.executor import BaseExecutor
 from booktracker.common.dao.hydrator import Hydrator
 from databases import Database
@@ -7,7 +9,7 @@ app = Sanic.get_app("BooktrackerApp")
 
 
 @app.before_server_start
-async def setup_postgres(app, _):
+async def setup_postgres(app: Sanic, _: Any) -> None:
     app.ctx.postgres = Database(
         app.config.POSTGRES_DSN,
         min_size=app.config.POSTGRES_MIN,
@@ -16,15 +18,15 @@ async def setup_postgres(app, _):
 
 
 @app.after_server_start
-async def connect_postgres(app, _):
+async def connect_postgres(app: Sanic, _: Any) -> None:
     await app.ctx.postgres.connect()
 
 
 @app.after_server_start
-async def load_sql(app, _):
+async def load_sql(app: Sanic, _: Any) -> None:
     BaseExecutor.load(Hydrator())
 
 
 @app.after_server_stop
-async def shutdown_postgres(app, _):
+async def shutdown_postgres(app: Sanic, _: Any) -> None:
     await app.ctx.postgres.disconnect()

--- a/Chapter11/booktracker/application/booktracker/worker/redis.py
+++ b/Chapter11/booktracker/application/booktracker/worker/redis.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 import aioredis
 from sanic import Sanic
 
@@ -7,7 +5,7 @@ app = Sanic.get_app("BooktrackerApp")
 
 
 @app.before_server_start
-async def setup_redis(app: Sanic, _: Any) -> None:
+async def setup_redis(app: Sanic, _) -> None:
     app.ctx.redis_pool = aioredis.BlockingConnectionPool.from_url(
         app.config.REDIS_DSN, max_connections=app.config.REDIS_MAX
     )
@@ -15,5 +13,5 @@ async def setup_redis(app: Sanic, _: Any) -> None:
 
 
 @app.after_server_stop
-async def shutdown_redis(app: Sanic, _: Any) -> None:
+async def shutdown_redis(app: Sanic, _) -> None:
     await app.ctx.redis_pool.disconnect()

--- a/Chapter11/booktracker/application/booktracker/worker/redis.py
+++ b/Chapter11/booktracker/application/booktracker/worker/redis.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import aioredis
 from sanic import Sanic
 
@@ -5,7 +7,7 @@ app = Sanic.get_app("BooktrackerApp")
 
 
 @app.before_server_start
-async def setup_redis(app, _):
+async def setup_redis(app: Sanic, _: Any) -> None:
     app.ctx.redis_pool = aioredis.BlockingConnectionPool.from_url(
         app.config.REDIS_DSN, max_connections=app.config.REDIS_MAX
     )
@@ -13,5 +15,5 @@ async def setup_redis(app, _):
 
 
 @app.after_server_stop
-async def shutdown_redis(app, _):
+async def shutdown_redis(app: Sanic, _: Any) -> None:
     await app.ctx.redis_pool.disconnect()

--- a/Chapter11/booktracker/application/booktracker/worker/request.py
+++ b/Chapter11/booktracker/application/booktracker/worker/request.py
@@ -1,7 +1,8 @@
 from typing import Any
 
-from booktracker.common.eid import generate
 from sanic import Request
+
+from booktracker.common.eid import generate
 
 
 class BooktrackerRequest(Request):

--- a/Chapter11/booktracker/application/booktracker/worker/request.py
+++ b/Chapter11/booktracker/application/booktracker/worker/request.py
@@ -1,8 +1,10 @@
+from typing import Any
+
 from booktracker.common.eid import generate
 from sanic import Request
 
 
 class BooktrackerRequest(Request):
     @classmethod
-    def generate_id(*_):
+    def generate_id(*_: Any) -> str:
         return generate()

--- a/Chapter11/booktracker/docker-compose.yml
+++ b/Chapter11/booktracker/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   app:
     tty: true
     build: ./application
+    user: "1000:1000"
     ports:
       - 7777:7777
       - 35729:35729
@@ -9,21 +10,27 @@ services:
       - db-postgres
       - db-redis
     command:
-      sanic
-      --port=7777
-      --host=0.0.0.0
-      --workers=1
-      --factory
-      --dev
-      --access-log
-      --reload-dir=./ui/src
-      booktracker.server:create_app
+      - wait-for-it
+      - "db-postgres:5432"
+      - --strict
+      - --
+      - wait-for-it
+      - "db-redis:6379"
+      - --strict
+      - --
+      - sanic
+      - --port=7777
+      - --host=0.0.0.0
+      - --workers=1
+      - --factory
+      - --dev
+      - --access-log
+      - --reload-dir=./ui/src
+      - booktracker.server:create_app
     volumes:
       - ./application/booktracker:/app/booktracker
       - ./application/ui:/app/ui
       - ./application/node_modules:/app/node_modules
-      - /home/adam/Projects/Sanic/sanic/sanic:/usr/local/lib/python3.10/site-packages/sanic
-      - /home/adam/Projects/Sanic/sanic-ext/sanic_ext:/usr/local/lib/python3.10/site-packages/sanic_ext
     environment:
       SANIC_LOCAL: "True"
       SANIC_POSTGRES_DSN: "postgres://postgres:foobar@db-postgres:5432"


### PR DESCRIPTION
- use `wait-for-it` to ensure `docker-compose up` works on first attempt.
- clean and sort imports
- homogenise typing usage
- remove unused `executor` argument from the `execute` decorator
- raise rather than return error in `execute` decorator

- Added typing to the `execute` decorator. But might be more
  complex than desired. Feel free to discard.
- Added overloads in the `hydrate` method for happier mypy
  This may be more complex than desired. Feel free to discard.